### PR TITLE
Fix `npm run test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,15 @@ Explore [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/
 These questions are selected from a set of exercises from a free repl.it classroom by [devmakers](https://repl.it/@devmakers).
 
 To run the tests:
-- inside of the root folder, run command `npm i` to install node packages
-- open `index.js` to find the javascript functions to complete
-- instructions are found inside each function
-- open `index.html` in a browser
-- open `index.test.js` and remove the `x` from each test suite you want to run
+
+- Inside of the root folder, run command `npm install` to install node packages
+- Open `index.js` to find the javascript functions to complete
+- Instructions are found inside each function
+- Run `npm run test` to automatically open `index.html` in a browser
+  - After completing a function or enabling a new test, refresh the page for the test to run again
+- Open `index.test.js` and remove the `x` from each test suite you want to run
   - `xdescribe` (inactive) ---> `describe` (active)
-  - the first test `getAllElementsButNth` is already active for you as an example
-- there are multiple unit tests testing edge cases and other expectations for each function to be completed
-- active tests will be red until you complete the function
-- once you fulfill the requirements for the tests, you will see green dots, hooray!
-
-
-
-
+  - The first test `getAllElementsButNth` is already active for you as an example
+- There are multiple unit tests testing edge cases and other expectations for each function to be completed
+- Active tests will be red until you complete the function
+- Once you fulfill the requirements for the tests, you will see green dots, hooray!

--- a/index.html
+++ b/index.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <title>Testing with Jasmine</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.css">
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.css"
+    />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine-html.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/boot.min.js"></script>
     <script src="index.js"></script>
     <script src="index.test.js"></script>
-</head>
-<body>
-</body>
+  </head>
+  <body></body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,38 +1,30 @@
 function getAllElementsButNth(arr, n) {
   // Given an array and an index, “getAllElementsButNth” returns an array with all the elements but the nth.
-
   // var output = getAllElementsButNth(['a', 'b', 'c'], 1);
   // console.log(output); // --> ['a', 'c']
-
   /* YOUR CODE HERE */
-
 }
 
 function getElementsThatEqual10AtProperty(obj, key) {
   // Given an object and a key, “getElementsThatEqual10AtProperty” returns an array containing all the elements of the array located at the given key that are equal to ten.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If the array contains no elements that are equal to 10, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the key, it should return an empty array.
-
   // var obj = {
   //   key: [1000, 10, 50, 10]
   // };
   // var output = getElementsThatEqual10AtProperty(obj, 'key');
   // console.log(output); // --> [10, 10]
-
   /* YOUR CODE HERE */
 }
 
 function select(arr, obj) {
   // Given an array and an object, “select” returns a new object whose properties are those in the given object AND whose keys are present in the given array.
-
   // Notes:
   // * If keys are present in the given array, but are not in the given object, it should ignore them.
   // * It does not modify the passed in object.
-
   // var arr = ['a', 'c', 'e'];
   // var obj = {
   //   a: 1,
@@ -42,220 +34,177 @@ function select(arr, obj) {
   // };
   // var output = select(arr, obj);
   // console.log(output); // --> { a: 1, c: 3 }
-
   /* YOUR CODE HERE */
 }
 
 function getElementsLessThan100AtProperty(obj, key) {
   // Given an object and a key, “getElementsLessThan100AtProperty” returns an array containing all the elements of the array located at the given key that are less than 100.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If the array contains no elements less than 100, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the key, it should return an empty array.
-
   // var obj = {
   //   key: [1000, 20, 50, 500]
   // };
   // var output = getElementsLessThan100AtProperty(obj, 'key');
   // console.log(output); // --> [20, 50]
-
   /* YOUR CODE HERE */
 }
 
 function getElementsGreaterThan10AtProperty(obj, key) {
   // Given an object and a key, “getElementsGreaterThan10AtProperty” returns an array containing the elements within the array, located at the given key, that are greater than 10.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If the array contains no elements greater than 10, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the key, it should return an empty array.
-
   // var obj = {
   //   key: [1, 20, 30]
   // };
   // var output = getElementsGreaterThan10AtProperty(obj, 'key');
   // console.log(output); // --> [20, 30]
-
   /* YOUR CODE HERE */
 }
 
 function removeElement(arr, discarder) {
   // Given an array of elements, and a “discarder” parameter, “removeElement” returns an array containing the items in the given array that do not match the “discarder” parameter.
-
   // Notes:
   // * If all the elements match, it should return an empty array.
   // * If an empty array is passed in, it should return an empty array.
-
   // var output = removeElement([1, 2, 3, 2, 1], 2);
   // console.log(output); // --> [1, 3, 1]
-
   /* YOUR CODE HERE */
 }
 
 function keep(arr, keeper) {
   // Given an array and a keeper element, “keep” returns an array containing the items that match the given keeper element.
-
   // Notes:
   // * If no elements match, “keep” should return an empty array.
-
   // var output = keep([1, 2, 3, 2, 1], 2)
   // console.log(output); --> [2, 2]
-
   /* YOUR CODE HERE */
 }
 
 function getOddLengthWordsAtProperty(obj, key) {
   // Given an object and a key, “getOddLengthWordsAtProperty” returns an array containing all the odd length word elements of the array located at the given key.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If it contains no odd length elements, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the given key, it should return an empty array.
-
   // var obj = {
   //   key: ['It', 'has', 'some', 'words']
   // };
   // var output = getOddLengthWordsAtProperty(obj, 'key');
   // console.log(output); // --> ['has', 'words']
-
   /* YOUR CODE HERE */
-
 }
 
 function computeAverageOfNumbers(nums) {
   // Given an array of numbers, “computeAverageOfNumbers” returns their average.
-
   // Notes:
   // * If given an empty array, it should return 0.
-
   // var input = [1,2,3,4,5];
   // var output = computeAverageOfNumbers(input);
   // console.log(output); // --> 3
-
   /* YOUR CODE HERE */
 }
 
 function getAverageOfElementsAtProperty(obj, key) {
   // Given an object and a key, “getAverageOfElementsAtProperty” returns the average of all the elements in the array located at the given key.
-
   // Notes:
   // * If the array at the given key is empty, it should return 0.
   // * If the property at the given key is not an array, it should return 0.
   // * If there is no property at the given key, it should return 0.
-
   // var obj = {
   //   key: [1, 2, 3]
   // };
   // var output = getAverageOfElementsAtProperty(obj, 'key');
   // console.log(output); // --> 2
-
   /* YOUR CODE HERE */
 }
 
 function getEvenLengthWordsAtProperty(obj, key) {
   // Given an object and a key, “getEvenLengthWordsAtProperty” returns an array containing all the even length word elements of the array located at the given key.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If it contains no even length elements, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the key, it should return an empty array.
-
   // var obj = {
   //   key: ['a', 'long', 'game']
   // };
   // var output = getEvenLengthWordsAtProperty(obj, 'key');
   // console.log(output); // --> ['long', 'game']
-
   /* YOUR CODE HERE */
 }
 
 function filterOddLengthWords(words) {
   // Given an array of string, “filterOddLengthWords” returns an array containing only the elements of the given array whose lengths are odd numbers.
-
   // var output = filterOddLengthWords(['there', 'it', 'is', 'now']);
   // console.log(output); // --> ['there', "now']
-
   /* YOUR CODE HERE */
 }
 
 function getSquaredElementsAtProperty(obj, key) {
   // Given an object and a key, “getSquaredElementsAtProperty” returns an array containing all the squared elements of the array located at the given key.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the key, it should return an empty array.
-
   // var obj = {
   //   key: [2, 1, 5]
   // };
   // var output = getSquaredElementsAtProperty(obj, 'key');
   // console.log(output); // --> [4, 1, 25]
-
   /* YOUR CODE HERE */
 }
 
 function getOddElementsAtProperty(obj, key) {
   // Given an object and a key, “getOddElementsAtProperty” returns an array containing all the odd elements of the array located at the given key.
-
   // Notes:
   // * If the array is empty, it should return an empty array.
   // * If it contains no odd elements, it should return an empty array.
   // * If the property at the given key is not an array, it should return an empty array.
   // * If there is no property at the key, it should return an empty array.
-
   // var obj = {
   //   key: [1, 2, 3, 4, 5]
   // };
   // var output = getOddElementsAtProperty(obj, 'key');
   // console.log(output); // --> [1, 3, 5]
-
   /* YOUR CODE HERE */
 }
 
 function getEvenElementsAtProperty(obj, key) {
-
-
   /* YOUR CODE HERE */
 }
 
 function filterEvenLengthWords(words) {
-
   /* YOUR CODE HERE */
 }
 
 function getLengthOfLongestElement(arr) {
-
   /* YOUR CODE HERE */
 }
 
 function getSmallestElementAtProperty(obj, key) {
-
   /* YOUR CODE HERE */
 }
 
 function getLargestElementAtProperty(obj, key) {
-
   /* YOUR CODE HERE */
 }
 
 function squareElements(arr) {
-
   /* YOUR CODE HERE */
 }
 
 function filterOddElements(arr) {
-
   /* YOUR CODE HERE */
 }
 
 function computeProductOfAllElements(arr) {
-
   /* YOUR CODE HERE */
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,111 +1,220 @@
 {
-  "name": "JS-Practice-for-webpt14",
+  "name": "js-practice-for-webpt14",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "lodash": "^4.17.14"
       }
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
       "dev": true
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "jasmine": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
-      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.4",
-        "jasmine-core": "~3.5.0"
-      }
-    },
-    "jasmine-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
+    "colors": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "ecstatic": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+      "dev": true,
+      "requires": {
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.5"
+      }
+    },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
+      "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.0.0"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-server": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.1.tgz",
+      "integrity": "sha512-T0jB+7J7GJ2Vo+a4/T7P7SbQ3x2GPDnqRqQXdfEuPuUOmES/9NBxPnDm7dh1HGEeUWqUmLUNtGV63ZC5Uy3tGA==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^1.0.3",
+        "colors": "^1.3.3",
+        "corser": "^2.0.1",
+        "ecstatic": "^3.3.2",
+        "http-proxy": "^1.17.0",
+        "opener": "^1.5.1",
+        "optimist": "~0.6.1",
+        "portfinder": "^1.0.20",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "opener": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
+      }
+    },
+    "portfinder": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+      "dev": true
+    },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "JS-Practice-for-webpt14",
+  "name": "js-practice-for-webpt14",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "jasmine"
-  },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
+  "scripts": {
+    "test": "http-server -s -f /index.html  -o index.html"
+  },
   "dependencies": {},
   "devDependencies": {
-    "jasmine": "^3.5.0"
+    "http-server": "^0.12.1"
   }
 }


### PR DESCRIPTION
This project was initially setup to use the global `jasmin` attached to the `window` from the Jasmine CDN scripts provided in `index.html`

Running `jasmine` with node is quite different in it's modules where it requires you to use `require()` to import the functions you want to test and use `module.exports` to export them.

While this project could be rewritten to use the node approach in terminal, I feel like the GUI in the browser makes for a better user experience, as such I have refined the process to make the transition of students to this project as smooth as possible.

Features of this PR:
 - Clear Readme
 - Only 1 npm package
 - `npm run test` command
 - Very small changes from upstream to reduce merge conflicts with upstream
 - Cleaned with Prettier 